### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/michaelstoffer/fieldops-hub/security/code-scanning/1](https://github.com/michaelstoffer/fieldops-hub/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/tests.yml` at the workflow root level (after the `on` section and before `jobs`). This applies to all jobs in the workflow unless overridden and is the least intrusive fix.

Best single fix without changing functionality:
- Add:
  - `permissions:`
  - `contents: read`

Why this works:
- `actions/checkout` requires `contents: read`.
- The remaining steps (`setup-*`, install, build, test) do not require repo write permissions in the shown workflow.
- This preserves behavior while enforcing least privilege.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
